### PR TITLE
Switch tasks between milestone 4 and 6

### DIFF
--- a/applications/nice1-tools-ecosystem.md
+++ b/applications/nice1-tools-ecosystem.md
@@ -222,7 +222,7 @@ Note: Some of the milestones can possibly overlap and be done in parallel.
 | 0a. | License |  Apache 2.0  |
 | 0b. | Documentation | Documentation for the frontend libraries for developers. |
 | 0c. | Unit tests | Unit tests for all the specified contracts, to ensure both proper functionality and better security. |
-| 1. | SC Profiles | Contract for members profiles management. |  
+| 1. | NFT Marketplace | A NFT marketplace taking data from both: simpleassets and atomichub. |  
 | 2. | SC Licenses | Contract for managing product licenses sold by developers / product sellers. |  
 
 ### Milestone 5 - Nice1 Link (Lvl2)
@@ -244,8 +244,9 @@ Note: Some of the milestones can possibly overlap and be done in parallel.
 | Number | Deliverable | Specification |
 | -----: | ----------- | ------------- |
 | 1. | Nice1 Link | Website for players and developers. |  
-| 1.a | NFT marketplace | A NFT marketplace taking data from both: simpleassets and atomichub. | 
-| 1.b | News section | A kind-of-a decentralized news section.. |  
+| 2. | SC Profiles | Contract for members profiles management. | 
+| 3. | News section | A kind-of-a decentralized news section. |  
+| 4. | NFTS viewer | Management and visualization of user NFTs  |  
 
 
 


### PR DESCRIPTION
### Project Abstract
Nice1 https://github.com/eosnetworkfoundation/grant-framework/pull/43

We are facing a problem of resources which prevents us from developing at the pace we had planned when we applied for the ENF grant. Even so, we have continued with the development, and we already have several parts that can be used and are available in the repositories. The problem is that not everything developed is under the same milestone, so we cannot close them to get the associated funds and have the resources to hire programmers to help us.

To solve this issue we could use the following change, which is much more in line with the reality of the development and the needs we have. We concentrate on Milestone 6, the tasks we have completed, and thus be able to send it for review and be able to collect the associated funds. That way we could give a boost to the rest of the milestones.

